### PR TITLE
Request timeout is HTTP 408, not 401

### DIFF
--- a/src/constants/status-codes.js
+++ b/src/constants/status-codes.js
@@ -1,5 +1,5 @@
 export const UNKNOWN = 0;
-export const REQUEST_TIMEOUT = 401; // client took too long
+export const REQUEST_TIMEOUT = 408; // client took too long
 export const TOO_MANY_REQUESTS = 429;
 export const SERVICE_UNAVAILABLE = 503;
 export const GATEWAY_TIMEOUT = 504;


### PR DESCRIPTION
401 is Unauthorized, so this causes retries against resources the client has been explicitly told it is not authorized to access. HTTP code 408 is Request Timeout